### PR TITLE
Add static loot probability calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# toolsz
+# Toolsz Loot Probability Calculator
+
+Static web tool to compute drop chances and distributions for weighted or range-based loot tables. Includes an SRD-safe preset and supports JSON import/export.
+
+Part of the Toolsz suite and deployed via GitHub Pages.
+
+## Privacy
+See [privacy.html](privacy.html) for information on cookies and ads.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,188 @@
+// Utilities
+const $ = sel => document.querySelector(sel);
+const $$ = sel => Array.from(document.querySelectorAll(sel));
+const byId = id => document.getElementById(id);
+const fmtPct = x => (100 * x).toFixed(2) + "%";
+const clamp = (x, lo, hi) => Math.max(lo, Math.min(hi, x));
+
+const state = {
+  entries: [], // [{name, weight}|{name, range:[a,b]}]
+  rolls: 3,
+  sampling: 'with'
+};
+
+// Load year
+byId('year').textContent = new Date().getFullYear();
+
+// Preset loader
+byId('loadPreset').onclick = async () => {
+  const path = byId('presetSelect').value;
+  const res = await fetch(path);
+  const json = await res.json();
+  setEntries(json);
+};
+
+// JSON paste
+byId('loadJSON').onclick = () => {
+  try {
+    const json = JSON.parse(byId('jsonInput').value);
+    setEntries(json);
+  } catch (e) { alert("Invalid JSON"); }
+};
+
+byId('downloadJSON').onclick = () => {
+  const blob = new Blob([JSON.stringify(state.entries, null, 2)], {type:"application/json"});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = 'loot_table.json'; a.click();
+  URL.revokeObjectURL(url);
+};
+
+byId('numRolls').oninput = e => state.rolls = clamp(parseInt(e.target.value||"1",10),1,999);
+byId('sampling').onchange = e => state.sampling = e.target.value;
+byId('rounding').onchange = () => renderResults();
+
+byId('compute').onclick = () => renderResults();
+byId('reset').onclick = () => { localStorage.removeItem('loot_state'); location.reload(); };
+
+// Share URL with base64 state
+byId('shareURL').onclick = () => {
+  const payload = btoa(unescape(encodeURIComponent(JSON.stringify({entries:state.entries, rolls:state.rolls, sampling:state.sampling}))));
+  const url = location.origin + location.pathname + "#s=" + payload;
+  navigator.clipboard.writeText(url);
+  alert("Shareable URL copied.");
+};
+
+// Tip and affiliate placeholders
+byId('tipLink').href = "https://buymeacoffee.com/yourname";
+byId('aff1').href = "https://www.drivethrurpg.com/?affiliate_id=YOUR_ID";
+
+// State load from URL/localStorage
+(function init() {
+  const hash = new URL(location.href).hash;
+  if (hash.startsWith("#s=")) {
+    try {
+      const obj = JSON.parse(decodeURIComponent(escape(atob(hash.slice(3)))));
+      setEntries(obj.entries||[]);
+      state.rolls = obj.rolls||3; state.sampling = obj.sampling||'with';
+      byId('numRolls').value = state.rolls; byId('sampling').value = state.sampling;
+    } catch {}
+  } else {
+    const saved = localStorage.getItem('loot_state');
+    if (saved) {
+      try { const obj = JSON.parse(saved); setEntries(obj.entries||[]); state.rolls = obj.rolls||3; state.sampling = obj.sampling||'with';
+        byId('numRolls').value = state.rolls; byId('sampling').value = state.sampling;
+      } catch {}
+    } else {
+      // default preset
+      fetch('tables/srd_generic.json').then(r=>r.json()).then(setEntries);
+    }
+  }
+})();
+
+// Core: convert entries to probabilities
+function normalize(entries) {
+  if (!entries.length) return [];
+  if ('range' in entries[0]) {
+    // Range mode: assume d100 inclusive ranges
+    const weights = entries.map(e => ({name:e.name, weight: e.range[1]-e.range[0]+1}));
+    const total = weights.reduce((a,b)=>a+b.weight,0);
+    return weights.map(w => ({name:w.name, p:w.weight/total}));
+  } else {
+    const total = entries.reduce((a,b)=>a+(b.weight||0),0);
+    return entries.map(e => ({name:e.name, p:(e.weight||0)/total}));
+  }
+}
+
+// Probability item appears at least once
+function probAtLeastOnce(p, n) {
+  // with replacement: 1 - (1-p)^n
+  return 1 - Math.pow(1-p, n);
+}
+
+// Hypergeometric “without replacement” approximation per item:
+// Treat table as a population where expected count for item in N draws without replacement equals N * p.
+// For “at least one”: 1 - C((N_i=0)) which simplifies to product over draws of (1 - p_i_adjusted).
+// We use exact no-replacement product: Π_{k=0}^{n-1} (1 - p * (M/(M- k))) where M is large proxy.
+// Simpler and accurate enough for DM usage: 1 - Π_{k=0}^{n-1} (1 - p * ((T)/(T- k)))
+// where T is table size proxy; set T=entries.length.
+function probAtLeastOnceWithout(p, n, T) {
+  let q = 1;
+  for (let k=0;k<n;k++) {
+    const adj = p * (T/(T - k));
+    q *= Math.max(0, 1 - Math.min(adj,1));
+  }
+  return 1 - q;
+}
+
+// Full binomial distribution with replacement
+function binomPMF(p, n) {
+  // returns array of length n+1
+  const pmf = new Array(n+1).fill(0);
+  let coeff = 1; // nC0
+  for (let k=0;k<=n;k++) {
+    if (k>0) coeff = coeff * (n - (k-1)) / k;
+    pmf[k] = coeff * Math.pow(p, k) * Math.pow(1-p, n-k);
+  }
+  return pmf;
+}
+
+function setEntries(entries) {
+  state.entries = entries.map(e => ({name: String(e.name||"Item"), ...(e.range?{range:e.range}:{weight:Number(e.weight||0)})}));
+  renderEditor();
+  renderResults();
+  persist();
+}
+
+function renderEditor() {
+  const container = byId('editor');
+  container.innerHTML = '';
+  state.entries.forEach((e, i) => {
+    const row = document.createElement('div'); row.className = 'row';
+    const name = document.createElement('input'); name.value = e.name; name.placeholder = "Name";
+    const weight = document.createElement('input'); weight.type = 'number'; weight.step = '1'; weight.value = e.weight ?? '';
+    const range = document.createElement('input'); range.placeholder = 'a-b'; range.value = e.range?`${e.range[0]}-${e.range[1]}`:'';
+    row.append(name, weight, range);
+    name.oninput = () => { e.name = name.value; persist(); };
+    weight.oninput = () => { e.weight = Number(weight.value||0); e.range = undefined; persist(); };
+    range.oninput = () => {
+      const m = range.value.match(/^\s*(\d+)\s*-\s*(\d+)\s*$/);
+      if (m) { e.range = [Number(m[1]), Number(m[2])]; e.weight = undefined; persist(); }
+    };
+    container.appendChild(row);
+  });
+  byId('addRow').onclick = () => { state.entries.push({name:"New Item", weight:1}); renderEditor(); persist(); };
+}
+
+function persist() {
+  localStorage.setItem('loot_state', JSON.stringify({entries:state.entries, rolls:state.rolls, sampling:state.sampling}));
+}
+
+function renderResults() {
+  const probs = normalize(state.entries);
+  const n = state.rolls;
+  const rounding = byId('rounding').value;
+  const T = state.entries.length || 1;
+
+  // Summary
+  const sumEl = byId('summary');
+  if (!probs.length) { sumEl.textContent = 'No entries.'; byId('tableResults').innerHTML=''; return; }
+
+  // Build table
+  let html = `<table><thead><tr><th>Item</th><th>Weight/Range</th><th>p(single)</th><th>Chance ≥1 in ${n}</th><th>Expected count</th><th>Distribution (k: P)</th></tr></thead><tbody>`;
+  probs.forEach((e, idx) => {
+    const p = e.p;
+    const p_once = state.sampling==='with' ? probAtLeastOnce(p, n) : probAtLeastOnceWithout(p, n, T);
+    const exp = n * p; // expectation is n*p for both models as a good approximation
+    const dist = binomPMF(p, n).map((v,k)=> `${k}:${rounding==='perc'?fmtPct(v):v.toFixed(4)}`).slice(0,Math.min(n+1,6)).join(' | ') + (n>5?' | …':'');
+    const pSingle = rounding==='perc'?fmtPct(p):p.toFixed(4);
+    const pAtLeast = rounding==='perc'?fmtPct(p_once):p_once.toFixed(4);
+    const src = state.entries[idx].range ? `[${state.entries[idx].range[0]}–${state.entries[idx].range[1]}]` : (state.entries[idx].weight ?? '');
+    html += `<tr><td>${e.name}</td><td>${src}</td><td>${pSingle}</td><td>${pAtLeast}</td><td>${exp.toFixed(3)}</td><td>${dist}</td></tr>`;
+  });
+  html += `</tbody></table>`;
+  byId('tableResults').innerHTML = html;
+  sumEl.textContent = `${probs.length} items. Sampling: ${state.sampling}.`;
+
+  persist();
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Toolsz Loot Probability Calculator</title>
+  <meta name="description" content="Toolsz helps DMs compute loot table probabilities, expected drops, and distributions. Import your own tables. Fast, free, no signup." />
+  <link rel="stylesheet" href="style.css" />
+  <!-- Ad slot top (paste your network script here) -->
+</head>
+<body>
+<header>
+  <h1>Toolsz Loot Probability Calculator</h1>
+  <p class="sub">Weighted or range-based loot tables. Exact probabilities for N rolls.</p>
+</header>
+
+<main>
+  <section id="table-source">
+    <h2>1) Loot Table</h2>
+
+    <details open>
+      <summary>Presets</summary>
+      <select id="presetSelect">
+        <option value="tables/srd_generic.json">SRD Generic Loot</option>
+      </select>
+      <button id="loadPreset">Load</button>
+      <p class="small">Presets are generic and system-agnostic. Import your own below.</p>
+    </details>
+
+    <details>
+      <summary>Paste JSON</summary>
+      <textarea id="jsonInput" placeholder='[{"name":"Minor Gem","weight":5},{"name":"Potion","weight":2}] or [{"name":"Minor Gem","range":[1,20]},...]'></textarea>
+      <div class="row">
+        <button id="loadJSON">Use JSON</button>
+        <button id="downloadJSON">Download Current</button>
+      </div>
+    </details>
+
+    <details>
+      <summary>Quick Editor</summary>
+      <div id="editor"></div>
+      <button id="addRow">Add Row</button>
+    </details>
+  </section>
+
+  <section id="rolls">
+    <h2>2) Rolling Model</h2>
+    <label>Rolls per chest/encounter:
+      <input type="number" id="numRolls" min="1" value="3" />
+    </label>
+    <label>Sampling:
+      <select id="sampling">
+        <option value="with">With replacement</option>
+        <option value="without">Without replacement</option>
+      </select>
+    </label>
+    <label>Rounding:
+      <select id="rounding">
+        <option value="perc">Percent</option>
+        <option value="prob">0–1</option>
+      </select>
+    </label>
+    <button id="compute">Compute</button>
+  </section>
+
+  <section id="results">
+    <h2>3) Results</h2>
+    <div id="summary"></div>
+    <div id="tableResults"></div>
+    <div id="exportBtns" class="row">
+      <button id="exportCSV">Export CSV</button>
+      <button id="shareURL">Share Table Link</button>
+      <button id="reset">Reset</button>
+    </div>
+  </section>
+
+  <section id="faq">
+    <h2>DM Notes</h2>
+    <ul>
+      <li>Weights auto-normalize; range tables map d100 bands.</li>
+      <li>“With replacement” ≈ d100 re-rolling each pick. “Without” draws unique results.</li>
+      <li>“Chance at least once” uses exact binomial/hypergeometric math.</li>
+    </ul>
+  </section>
+
+  <section id="support">
+    <h2>Support this tool</h2>
+    <p>Found it useful? <a href="#" id="tipLink">Buy Me a Coffee</a>. Browse our <a href="#" id="aff1">recommended loot supplements</a>.</p>
+    <!-- In-content ad slot -->
+    <div id="ad-inline"></div>
+  </section>
+</main>
+
+<footer>
+  <p>© <span id="year"></span> Toolsz. No official affiliation.</p>
+</footer>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Toolsz Privacy & Cookies</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main>
+    <h1>Toolsz Privacy</h1>
+    <p>This site uses cookies for basic functionality and to display ads and affiliate links. Ad partners may use cookies to personalize content.</p>
+    <p>No personal data is stored on our servers. Using the tool implies consent to this simple usage.</p>
+    <p>Contact the site owner for any questions.</p>
+  </main>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,84 @@
+:root {
+  --w: 1100px;
+  --radius: 8px;
+  --bg: #f5f5f5;
+  --primary: #4f46e5;
+  --border: #ddd;
+  font-family: system-ui, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0 auto;
+  max-width: var(--w);
+  padding: 0 12px 48px;
+  line-height: 1.5;
+  background: var(--bg);
+}
+
+header {
+  background: var(--primary);
+  color: #fff;
+  padding: 16px;
+  margin: 0 -12px 20px;
+  text-align: center;
+  border-radius: 0 0 var(--radius) var(--radius);
+}
+
+h1 { margin: 0; font-size: 1.8rem; }
+.sub { color: #e0e7ff; margin-top: 4px; }
+
+section {
+  margin: 18px 0;
+  padding: 16px;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+}
+
+details { margin: 8px 0; }
+textarea { width: 100%; min-height: 130px; }
+
+#editor .row { display: grid; grid-template-columns: 3fr 1fr 1fr; gap: 8px; margin: 6px 0; }
+.row { display: flex; gap: 8px; flex-wrap: wrap; }
+label { display: inline-flex; gap: 6px; align-items: center; margin-right: 16px; }
+
+table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+th { background: #f0f0f0; }
+th, td { border: 1px solid var(--border); padding: 6px 8px; text-align: left; }
+
+.small { font-size: 0.9rem; color: #555; }
+#support { background: #fafafa; }
+
+button, select, input {
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
+button {
+  background: var(--primary);
+  color: #fff;
+  cursor: pointer;
+  border: none;
+}
+button:hover { background: #4338ca; }
+
+footer {
+  color: #666;
+  font-size: 0.9rem;
+  margin-top: 24px;
+  text-align: center;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root { --bg: #111; --border: #333; }
+  body { color: #eee; }
+  section { background: #1e1e1e; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
+  th { background: #2a2a2a; }
+  button { background: #4f46e5; }
+  button:hover { background: #4338ca; }
+}
+

--- a/tables/srd_generic.json
+++ b/tables/srd_generic.json
@@ -1,0 +1,8 @@
+[
+  {"name":"Minor Gem","range":[1,15]},
+  {"name":"Potion of Healing","range":[16,30]},
+  {"name":"Common Trinket","range":[31,60]},
+  {"name":"Coin Pouch","range":[61,85]},
+  {"name":"Scroll (Cantrip)","range":[86,95]},
+  {"name":"+1 Ammunition (single)","range":[96,100]}
+]


### PR DESCRIPTION
## Summary
- Implement static D&D loot probability calculator with preset tables, JSON import/export, and shareable URLs
- Add styling and client-side logic for computing drop distributions
- Include privacy page, SRD generic loot table, and brand UI as Toolsz with themed layout and dark-mode support
