### PR TITLE
feat: add random loot generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# Toolsz – Loot Probability Calculator
+# Toolsz – D&D Loot Generator
 
-Static web tool to compute drop chances and distributions for weighted or range-based loot tables. Includes an SRD-safe preset and supports JSON import/export. Free to use and lightly monetized via ads, affiliate links, and an optional tip jar. Part of the Toolsz suite and deployed via GitHub Pages.
+Static web tool to compute drop chances, distributions, and generate random loot from weighted or range-based tables. Includes an SRD-safe preset and supports JSON import/export. Free to use and lightly monetized via ads, affiliate links, and an optional tip jar. Part of the Toolsz suite and deployed via GitHub Pages.
 
 ## Features
 - Quick start instructions and inline help
 - In-browser table editor with row deletion
+- Random loot generation based on the current table
 - Copyable results table, CSV export, and shareable links
 
-# Toolsz Loot Probability Calculator
+# Toolsz D&D Loot Generator
 
 
 Static web tool to compute drop chances and distributions for weighted or range-based loot tables. Includes an SRD-safe preset and supports JSON import/export. Free to use and lightly monetized via ads, affiliate links, and an optional tip jar. Part of the Toolsz suite and deployed via GitHub Pages.

--- a/app.js
+++ b/app.js
@@ -201,3 +201,42 @@ byId('copyTable').onclick = () => {
   navigator.clipboard.writeText(text);
   alert('Table copied to clipboard.');
 };
+function pickIndex(entries) {
+  const weights = entries.map(e => e.range ? (e.range[1] - e.range[0] + 1) : (e.weight || 0));
+  const total = weights.reduce((a, b) => a + b, 0);
+  let r = Math.random() * total;
+  for (let i = 0; i < entries.length; i++) {
+    r -= weights[i];
+    if (r < 0) return i;
+  }
+  return entries.length - 1;
+}
+
+function generateLoot() {
+  const pool = state.entries.slice();
+  const loot = [];
+  for (let i = 0; i < state.rolls; i++) {
+    if (!pool.length) break;
+    const idx = pickIndex(pool);
+    loot.push(pool[idx].name);
+    if (state.sampling === 'without') pool.splice(idx, 1);
+  }
+  return loot;
+}
+
+byId('rollLoot').onclick = () => {
+  const loot = generateLoot();
+  const out = byId('lootOutput');
+  out.innerHTML = '';
+  loot.forEach(name => {
+    const li = document.createElement('li');
+    li.textContent = name;
+    out.appendChild(li);
+  });
+  if (!loot.length) {
+    const li = document.createElement('li');
+    li.textContent = 'No loot.';
+    out.appendChild(li);
+  }
+};
+

--- a/index.html
+++ b/index.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Toolsz – Loot Probability Calculator</title>
-  <meta name="description" content="Toolsz – a fast D&D loot probability calculator letting you import tables, compute drop chances, and share results. Free, no signup." />
-  <title>Toolsz Loot Probability Calculator</title>
-  <meta name="description" content="Toolsz helps DMs compute loot table probabilities, expected drops, and distributions. Import your own tables. Fast, free, no signup." />
+  <title>Toolsz – D&D Loot Generator</title>
+  <meta name="description" content="Toolsz – a fast D&D loot generator letting you import tables, compute drop chances, and roll random loot. Free, no signup." />
+  <title>Toolsz D&D Loot Generator</title>
+  <meta name="description" content="Toolsz helps DMs generate random loot and compute drop chances. Import your own tables. Fast, free, no signup." />
   <link rel="stylesheet" href="style.css" />
   <!-- Ad slot top (paste your network script here) -->
 </head>
 <body>
 <header>
-  <h1>Toolsz – Loot Probability Calculator</h1>
-  <h1>Toolsz Loot Probability Calculator</h1>
+  <h1>Toolsz – D&D Loot Generator</h1>
+  <h1>Toolsz D&D Loot Generator</h1>
   <p class="sub">Weighted or range-based loot tables. Exact probabilities for N rolls.</p>
 </header>
 
@@ -25,6 +25,7 @@
         <li>Load a preset or enter your own table with weights or ranges.</li>
         <li>Choose how many rolls to simulate and whether results repeat.</li>
         <li>Hit <strong>Compute</strong> to see drop chances and distributions.</li>
+        <li>Hit <strong>Roll Loot</strong> to generate random drops.</li>
       </ol>
     </details>
   </section>
@@ -81,6 +82,8 @@
     <h2>3) Results</h2>
     <div id="summary"></div>
     <div id="tableResults"></div>
+    <button id="rollLoot">Roll Loot</button>
+    <ul id="lootOutput"></ul>
     <div id="exportBtns" class="row">
       <button id="exportCSV">Export CSV</button>
       <button id="shareURL">Share Table Link</button>


### PR DESCRIPTION
## Summary
- add button to roll random loot drops
- implement weighted selection to generate loot results
- document D&D loot generator capability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a77a20f7788325a3b8d1fe610a5c4e